### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+    contents: read
 
 on:
     push:


### PR DESCRIPTION
Potential fix for [https://github.com/Adithya-Rajendran/portfolio-website/security/code-scanning/5](https://github.com/Adithya-Rajendran/portfolio-website/security/code-scanning/5)

In general, this issue is fixed by adding an explicit `permissions` block to the workflow (or to individual jobs) that grants only the minimal scopes required. If a job only needs to read the repository contents (for checkout, linting, building), then `contents: read` is sufficient, and no write permissions are needed.

For this workflow, the simplest and least intrusive fix is to define a root-level `permissions` block directly under the workflow `name:` (before `on:`). This will apply to both `lint` and `build` jobs, and it aligns with the CodeQL suggestion of using `contents: read` as a minimal starting point. No changes to any steps are required, and existing functionality (checkout, Node setup, npm install, lint, TypeScript compile, build) will continue to work because `actions/checkout` only requires read access to repository contents. Concretely, in `.github/workflows/node.js.yml`, add:

```yaml
permissions:
    contents: read
```

between line 1 (`name: CI`) and line 3 (`on:`). No imports or additional definitions are necessary.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
