### PR TITLE
Fix the three accessibility issues Lighthouse flagged

### DIFF
--- a/app/blogs/[slug]/page.tsx
+++ b/app/blogs/[slug]/page.tsx
@@ -66,21 +66,23 @@ export default async function BlogPostPage({
     if (!meta) notFound();
 
     return (
-        <article id="main-content" tabIndex={-1} className="w-full">
-            <BlogPostJsonLd
-                title={meta.title || ""}
-                description={meta.description || ""}
-                date={meta.date || ""}
-                slug={slug}
-            />
+        <main id="main-content" tabIndex={-1} className="w-full">
+            <article>
+                <BlogPostJsonLd
+                    title={meta.title || ""}
+                    description={meta.description || ""}
+                    date={meta.date || ""}
+                    slug={slug}
+                />
 
-            <BlogPostHero post={meta} />
+                <BlogPostHero post={meta} />
 
-            {/* Body streams in after shiki highlighting completes */}
-            <Suspense fallback={<BodySkeleton />}>
-                <BodyWithData slug={slug} />
-            </Suspense>
-        </article>
+                {/* Body streams in after shiki highlighting completes */}
+                <Suspense fallback={<BodySkeleton />}>
+                    <BodyWithData slug={slug} />
+                </Suspense>
+            </article>
+        </main>
     );
 }
 

--- a/components/blogs/post-card.tsx
+++ b/components/blogs/post-card.tsx
@@ -108,13 +108,7 @@ export default function PostCard({ post, variant = "list" }: PostCardProps) {
     const imageUrl = getPostImageUrl(post, v.image.width, v.image.height);
 
     return (
-        <Card
-            href={`/blogs/${slug}`}
-            aria-label={`Read more about ${title}`}
-            title={`Read more about ${title}`}
-            flush
-            className="flex flex-col h-full"
-        >
+        <Card href={`/blogs/${slug}`} flush className="flex flex-col h-full">
             {imageUrl && (
                 <div className={`relative overflow-hidden ${v.aspect}`}>
                     <Image

--- a/components/portfolio/certification.tsx
+++ b/components/portfolio/certification.tsx
@@ -45,7 +45,7 @@ export default function Certification(cert: TCertification) {
                         </p>
                     )}
                     {dateRange && (
-                        <p className="mt-2 text-xs uppercase tracking-wider text-slate-500 dark:text-slate-500">
+                        <p className="mt-2 text-xs uppercase tracking-wider text-slate-500 dark:text-slate-400">
                             {dateRange}
                         </p>
                     )}


### PR DESCRIPTION
## Context

Ran Lighthouse (mobile) against production on the blog routes (priority) plus home/portfolio for reference. Scores were already strong — **Perf 95–97, Best-Practices 100, SEO 100, CLS 0** everywhere — so this PR only fixes the three real accessibility defects it surfaced.

| Route | Perf | A11y | BP | SEO | LCP | CLS | TBT |
|---|---|---|---|---|---|---|---|
| /blogs | 95 | 100* | 100 | 100 | 2.6s | 0 | 140ms |
| /blogs/[slug] | 97 | 98 | 100 | 100 | 2.4s | 0 | 120ms |
| / | 95 | 100 | 100 | 100 | 2.7s | 0 | 110ms |
| /portfolio | 95 | 96 | 100 | 100 | 2.9s | 0 | 50ms |

\* axe flagged label-in-name on /blogs even at score 100.

## Fixes

- **Blog post `<main>` landmark** (WCAG 1.3.1): the route rendered a bare `<article id="main-content">` with no `main` landmark. Wrapped in `<main>` (skip link still targets it).
- **Blog cards label-in-name** (WCAG 2.5.3): `PostCard` set `aria-label="Read more about {title}"`, overriding the card's visible text (date · reading time · title · description) with a name that didn't contain it. Removed the redundant `aria-label`/`title` so the accessible name *is* the visible content.
- **Certification date contrast** (WCAG 1.4.3): `dark:text-slate-500` on the dark card measured 3.74:1 → `slate-400`, matching the footer/ToC contrast fixes already shipped.

## Deliberately skipped (flagged, not worth it)

- ~23KB "unused JavaScript" — it's react-dom framework code, not app code
- ~13KB legacy polyfills (`Array.prototype.at/flat/flatMap`, `Object.fromEntries`) — injected by Next/Turbopack per browserslist, not cleanly tunable, marginal
- render-blocking 13KB stylesheet — inherent to a styled site; FCP is already 1.0s
- ~20KB oversized body image on a post — lazy-loaded below the fold, **zero LCP/FCP impact** per Lighthouse's own metricSavings

## Verification

- lint / typecheck / format / 13 tests / `next build` (CI sentinel) green
- Will re-run Lighthouse on the blog routes after merge to confirm A11y → 100

🤖 Generated with [Claude Code](https://claude.com/claude-code)