### PR TITLE
Liquid-glass × One UI 8.5/9 backdrop

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -403,107 +403,177 @@
 }
 
 /* ─────────────────────────────────────────────────────────────────────
-   Animated gradient mesh background — softer than before so cards
-   feel like they sit on a calm wallpaper, not a strobing one.
+   LIQUID-GLASS CHROME — the floating chrome refracts the backdrop where
+   the browser can. Chromium supports SVG filters in backdrop-filter;
+   Safari/Firefox don't, so this is a progressive enhancement layered
+   over the frosted base in @layer components above. If a browser drops
+   the url() declaration it simply keeps that frost. Slightly lower fills
+   let the lensing read through. Unlayered so it wins over the base.
+   ───────────────────────────────────────────────────────────────────── */
+@supports (backdrop-filter: url(#x)) or (-webkit-backdrop-filter: url(#x)) {
+    .os-nav {
+        background: rgba(255, 255, 255, 0.72);
+        backdrop-filter: blur(20px) saturate(180%) url(#glass-refract);
+        -webkit-backdrop-filter: blur(20px) saturate(180%) url(#glass-refract);
+    }
+    .dark .os-nav {
+        background: rgba(15, 17, 26, 0.7);
+    }
+    .os-card-raised {
+        background: rgba(255, 255, 255, 0.88);
+        backdrop-filter: blur(22px) saturate(170%) url(#glass-refract);
+        -webkit-backdrop-filter: blur(22px) saturate(170%) url(#glass-refract);
+    }
+    .dark .os-card-raised {
+        background: rgba(28, 30, 40, 0.86);
+    }
+}
+
+/* ─────────────────────────────────────────────────────────────────────
+   LIQUID-GLASS BACKDROP — a calm One UI colour field given organic,
+   refracted "liquid glass" edges via a static SVG displacement filter
+   (#glass-liquid, defined once in app/layout.tsx). Three layers, all
+   fixed and behind content:
+     1. base wash (.mesh-bg bg)  — the subtle colour, richer than canvas
+     2. liquid orbs (::before/after) — drifting blobs warped to glass
+     3. frosted grain (.bg-grain)    — the fine glass-surface texture
    ───────────────────────────────────────────────────────────────────── */
 
 .mesh-bg {
     position: fixed;
     inset: 0;
-    z-index: -1;
+    z-index: -2;
     overflow: hidden;
     pointer-events: none;
+    background:
+        radial-gradient(
+            120% 80% at 12% -10%,
+            rgb(var(--mesh-a) / 0.1),
+            transparent 60%
+        ),
+        radial-gradient(
+            120% 90% at 105% 15%,
+            rgb(var(--mesh-b) / 0.1),
+            transparent 55%
+        ),
+        radial-gradient(
+            110% 110% at 50% 120%,
+            rgb(var(--c3) / 0.08),
+            transparent 60%
+        );
 }
 
+.dark .mesh-bg {
+    background:
+        radial-gradient(
+            120% 80% at 12% -10%,
+            rgb(var(--mesh-a) / 0.14),
+            transparent 60%
+        ),
+        radial-gradient(
+            120% 90% at 105% 15%,
+            rgb(var(--mesh-b) / 0.12),
+            transparent 55%
+        ),
+        radial-gradient(
+            110% 110% at 50% 120%,
+            rgb(var(--c3) / 0.1),
+            transparent 60%
+        );
+}
+
+/* Liquid orbs — blurred blobs displaced into organic glass shapes. The
+   displacement filter is static (fixed seed); motion is translate-only so
+   the filtered layer stays cached and rasterises once, not per frame. */
 .mesh-bg::before,
 .mesh-bg::after {
     content: "";
     position: absolute;
     border-radius: 50%;
-    filter: blur(100px);
-    opacity: 0.28;
+    filter: blur(42px) url(#glass-liquid);
+    opacity: 0.42;
     will-change: transform;
     transition: background 0.6s ease;
 }
 
 .mesh-bg::before {
-    top: -15%;
-    right: -15%;
-    width: 60rem;
-    height: 60rem;
+    top: -16%;
+    right: -14%;
+    width: 52rem;
+    height: 52rem;
     background: radial-gradient(
         circle at center,
-        rgb(var(--mesh-a) / 0.45),
-        rgb(var(--mesh-a) / 0) 65%
+        rgb(var(--mesh-a) / 0.5),
+        rgb(var(--mesh-a) / 0) 60%
     );
-    animation: drift-a 38s ease-in-out infinite alternate;
+    animation: drift-a 42s ease-in-out infinite alternate;
 }
 
 .mesh-bg::after {
     bottom: -20%;
-    left: -15%;
-    width: 50rem;
-    height: 50rem;
+    left: -14%;
+    width: 46rem;
+    height: 46rem;
     background: radial-gradient(
         circle at center,
-        rgb(var(--mesh-b) / 0.35),
-        rgb(var(--mesh-b) / 0) 65%
+        rgb(var(--mesh-b) / 0.42),
+        rgb(var(--mesh-b) / 0) 60%
     );
-    animation: drift-b 44s ease-in-out infinite alternate;
+    animation: drift-b 50s ease-in-out infinite alternate;
 }
 
 .dark .mesh-bg::before {
+    opacity: 0.5;
     background: radial-gradient(
         circle at center,
-        rgb(var(--mesh-a) / 0.28),
-        rgb(var(--mesh-a) / 0) 65%
+        rgb(var(--mesh-a) / 0.32),
+        rgb(var(--mesh-a) / 0) 60%
     );
-    opacity: 0.42;
 }
 
 .dark .mesh-bg::after {
+    opacity: 0.45;
     background: radial-gradient(
         circle at center,
-        rgb(var(--mesh-b) / 0.22),
-        rgb(var(--mesh-b) / 0) 65%
+        rgb(var(--mesh-b) / 0.26),
+        rgb(var(--mesh-b) / 0) 60%
     );
-    opacity: 0.38;
 }
 
 @keyframes drift-a {
     from {
-        transform: translate(0, 0) scale(1);
+        transform: translate(0, 0);
     }
     to {
-        transform: translate(-4rem, 3rem) scale(1.08);
+        transform: translate(-4rem, 3rem);
     }
 }
 
 @keyframes drift-b {
     from {
-        transform: translate(0, 0) scale(1);
+        transform: translate(0, 0);
     }
     to {
-        transform: translate(3rem, -4rem) scale(1.04);
+        transform: translate(3rem, -4rem);
     }
 }
 
-/* Subtle dot-grid texture overlay */
-.dot-grid {
-    background-image: radial-gradient(
-        circle at 1px 1px,
-        rgba(15, 23, 42, 0.04) 1px,
-        transparent 0
-    );
-    background-size: 28px 28px;
+/* Frosted grain — fine glass-surface texture over the colour field.
+   Static inline SVG noise (self-contained filter), soft-light blended
+   at low opacity. Replaces the old dot-grid. */
+.bg-grain {
+    position: fixed;
+    inset: 0;
+    z-index: -1;
+    pointer-events: none;
+    opacity: 0.45;
+    mix-blend-mode: soft-light;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='160' height='160'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='2' stitchTiles='stitch'/%3E%3CfeColorMatrix type='saturate' values='0'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
+    background-size: 160px 160px;
 }
 
-.dark .dot-grid {
-    background-image: radial-gradient(
-        circle at 1px 1px,
-        rgba(255, 255, 255, 0.035) 1px,
-        transparent 0
-    );
+.dark .bg-grain {
+    opacity: 0.55;
 }
 
 /* ─────────────────────────────────────────────────────────────────────

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -127,14 +127,80 @@ export default function RootLayout({
                     Skip to content
                 </a>
 
-                {/* Animated mesh background (orbs drift, blurred) */}
-                <div className="mesh-bg" aria-hidden="true" />
-
-                {/* Static dot grid texture overlay */}
-                <div
-                    className="dot-grid pointer-events-none fixed inset-0 -z-10 opacity-60 dark:opacity-50"
+                {/* Liquid-glass SVG filters — referenced only by url(#id)
+                    from globals.css. #glass-liquid warps the backdrop orbs
+                    into organic shapes; #glass-refract lenses the backdrop
+                    through the floating chrome (Chromium). Hidden, 0×0. */}
+                <svg
                     aria-hidden="true"
-                />
+                    width="0"
+                    height="0"
+                    style={{ position: "absolute" }}
+                >
+                    <defs>
+                        <filter
+                            id="glass-liquid"
+                            x="-20%"
+                            y="-20%"
+                            width="140%"
+                            height="140%"
+                            colorInterpolationFilters="sRGB"
+                        >
+                            <feTurbulence
+                                type="fractalNoise"
+                                baseFrequency="0.008 0.012"
+                                numOctaves={2}
+                                seed={7}
+                                result="n"
+                            />
+                            <feGaussianBlur
+                                in="n"
+                                stdDeviation="1.5"
+                                result="nb"
+                            />
+                            <feDisplacementMap
+                                in="SourceGraphic"
+                                in2="nb"
+                                scale={68}
+                                xChannelSelector="R"
+                                yChannelSelector="G"
+                            />
+                        </filter>
+                        <filter
+                            id="glass-refract"
+                            x="-15%"
+                            y="-15%"
+                            width="130%"
+                            height="130%"
+                            colorInterpolationFilters="sRGB"
+                        >
+                            <feTurbulence
+                                type="fractalNoise"
+                                baseFrequency="0.014 0.014"
+                                numOctaves={2}
+                                seed={11}
+                                result="n"
+                            />
+                            <feGaussianBlur
+                                in="n"
+                                stdDeviation="0.7"
+                                result="nb"
+                            />
+                            <feDisplacementMap
+                                in="SourceGraphic"
+                                in2="nb"
+                                scale={22}
+                                xChannelSelector="R"
+                                yChannelSelector="G"
+                            />
+                        </filter>
+                    </defs>
+                </svg>
+
+                {/* Liquid-glass backdrop: colour wash + drifting refracted
+                    orbs (.mesh-bg), then the frosted glass grain (.bg-grain) */}
+                <div className="mesh-bg" aria-hidden="true" />
+                <div className="bg-grain" aria-hidden="true" />
 
                 <Suspense>
                     <ThemeContextProvider>


### PR DESCRIPTION
## What

Makes the background "more than it was" while keeping the brief — *just a
subtle colour* — by fusing Apple-style **liquid glass** with our One UI
8.5/9 language. The two flat blurred orbs become a layered liquid-glass
field; the floating chrome refracts it; content cards stay One UI-opaque.

## How

**Backdrop (all browsers)** — three fixed layers behind content:
1. a richer colour **wash** (`--mesh-a/-b` + `--c3`) instead of the bare canvas,
2. two drifting **orbs warped into organic, refracted shapes** by a *static* SVG `feTurbulence`+`feDisplacementMap` filter (`#glass-liquid`) — motion is **translate-only** so the filtered layer caches and rasterises once,
3. a frosted **SVG-noise grain** (`soft-light`) replacing the dot-grid as the glass-surface texture.

**Floating chrome (Chromium, graceful elsewhere)** — `.os-nav` and `.os-card-raised` refract the backdrop via `backdrop-filter: … url(#glass-refract)`, gated behind `@supports`. The base frost stays valid, so Safari/Firefox (which don't render SVG backdrop filters) simply keep today's frost. Slightly lower chrome fills let the lensing read through; content cards are untouched.

SVG filter defs are mounted once, hidden, in `app/layout.tsx`; referenced only by `url(#id)` from `globals.css`.

## Verification

- **Refraction confirmed in Chromium**: a striped-backdrop test bar shows clear liquid lensing inside, straight outside.
- **All 4 accent themes × light/dark** screenshotted on home + portfolio — rich but subtle; cards stay opaque.
- **Performance-neutral** (A/B, same localhost env, Lighthouse mobile): new vs main is within noise on every route — home 89 vs 88, blogs 92 vs 92, portfolio 90 vs 89; **CLS 0**, **TBT 40–70ms**, **A11y 100** throughout. The static-filter + translate-only design kept the displacement off the per-frame path.
- lint / typecheck / format / 13 tests / `next build` (CI sentinel) green.

Browser note: the *colour/liquid backdrop* works everywhere; only the *chrome lensing* is Chromium-only, with a clean frosted fallback. Reduced-motion freezes the drift; the static liquid look remains. All layers are `aria-hidden` / `pointer-events:none`.

The design-system repo will be synced to match in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)